### PR TITLE
feat: 新增 NoteService 和 NoteController 單元測試

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.3.232</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
@@ -72,6 +79,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
         </dependency>
 
         <dependency>

--- a/src/test/java/com/jeannychiu/learningnotesapi/controller/NoteControllerTest.java
+++ b/src/test/java/com/jeannychiu/learningnotesapi/controller/NoteControllerTest.java
@@ -1,0 +1,78 @@
+package com.jeannychiu.learningnotesapi.controller;
+
+import com.jeannychiu.learningnotesapi.model.Note;
+import com.jeannychiu.learningnotesapi.service.NoteService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class NoteControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NoteService noteService;
+
+    @Test
+    @WithMockUser(username = "test@example.com")
+    void testGetNotes() throws Exception {
+        // 測試 GET /notes
+        // 1. 準備測試資料
+        Note note = new Note();
+        note.setId(1L);
+        note.setTitle("測試標題");
+        note.setContent("測試內容");
+        note.setUserEmail("test@example.com");
+
+        List<Note> notes = Arrays.asList(note);
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Note> page = new PageImpl<>(notes, pageable, notes.size());
+
+        // 2. 設定Mock行為
+        when(noteService.getAllNotes(any(), anyString(), anyBoolean())).thenReturn(page);
+
+        // 3. 建立 RequestBuilder
+        RequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/notes")
+                .param("page", "0")
+                .param("size", "10");
+
+        // 4. 執行測試
+        MvcResult mvcResult = mockMvc.perform(requestBuilder)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].title", equalTo("測試標題")))
+                .andExpect(jsonPath("$.content[0].content", equalTo("測試內容")))
+                .andExpect(jsonPath("$.content[0].userEmail", equalTo("test@example.com")))
+                .andExpect(jsonPath("$.totalElements", equalTo(1)))
+                .andExpect(jsonPath("$.pageable.pageNumber", equalTo(0)))
+                .andExpect(jsonPath("$.pageable.pageSize", equalTo(10)))
+                .andReturn();
+
+        // 5. 檢查回應內容
+        String responseContent = mvcResult.getResponse().getContentAsString();
+        System.out.println("Response回應 : " + responseContent);
+    }
+}

--- a/src/test/java/com/jeannychiu/learningnotesapi/service/NoteServiceTest.java
+++ b/src/test/java/com/jeannychiu/learningnotesapi/service/NoteServiceTest.java
@@ -1,0 +1,110 @@
+package com.jeannychiu.learningnotesapi.service;
+
+import com.jeannychiu.learningnotesapi.model.Note;
+import com.jeannychiu.learningnotesapi.repository.NoteRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class NoteServiceTest {
+    @Autowired
+    private NoteService noteService;
+
+    private String testUserEmail;
+
+    @BeforeEach
+    void setUp() {
+        testUserEmail = "test@example.com";
+    }
+
+    @Test
+    void testCreateNote() {
+        // 測試創建筆記
+        // 準備測試資料
+        Note note = new Note();
+        note.setTitle("測試標題 with English & 特殊符號!@#");
+        note.setContent("這是一段較長的測試內容...");
+
+        // 執行測試
+        Note createdNote = noteService.createNote(note, testUserEmail);
+
+        // 驗證結果
+        // 基本驗證
+        assertNotNull(createdNote);
+        assertNotNull(createdNote.getId());
+
+        // 內容驗證
+        assertEquals("測試標題 with English & 特殊符號!@#", createdNote.getTitle());
+        assertEquals("這是一段較長的測試內容...", createdNote.getContent());
+        assertEquals(testUserEmail, createdNote.getUserEmail());
+
+        // 時間戳記
+        assertNotNull(createdNote.getCreatedAt());
+        assertNotNull(createdNote.getUpdatedAt());
+    }
+
+    @Test
+    void testGetNotes() {
+        // 測試查詢筆記 - 一般使用者查詢自己的筆記
+        // 準備測試資料
+        Note note1 = new Note();
+        note1.setTitle("測試標題1");
+        note1.setContent("測試內容1");
+
+        Note note2 = new Note();
+        note2.setTitle("測試標題2");
+        note2.setContent("測試內容2");
+
+        noteService.createNote(note1, testUserEmail);
+        noteService.createNote(note2, testUserEmail);
+
+        // 執行測試
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Note> allNotes = noteService.getAllNotes(pageable, testUserEmail, false);
+
+        // 驗證結果
+        assertTrue(allNotes.getTotalElements() >= 2);
+        allNotes.getContent().forEach(note -> {
+            assertEquals(testUserEmail, note.getUserEmail());
+            assertNotNull(note.getId());
+            assertNotNull(note.getTitle());
+            assertNotNull(note.getContent());
+        });
+    }
+
+    @Test
+    void testUpdateNote() {
+        // 測試更新筆記
+        // 準備測試資料
+        Note originalNote = new Note();
+        originalNote.setTitle("原始標題");
+        originalNote.setContent("原始內容");
+
+        Note saved = noteService.createNote(originalNote, testUserEmail);
+
+        Note newNote = new Note();
+        newNote.setTitle("新標題");
+        newNote.setContent("新內容");
+
+        // 執行測試
+        Note updated = noteService.updateNote(saved.getId(), newNote, testUserEmail, false);
+
+        // 驗證結果
+        assertNotNull(updated);
+        assertEquals(saved.getId(), updated.getId());
+        assertEquals("新標題", updated.getTitle());
+        assertEquals("新內容", updated.getContent());
+        assertEquals(testUserEmail, updated.getUserEmail());
+        assertNotNull(updated.getUpdatedAt());
+        assertTrue(updated.getUpdatedAt().isAfter(saved.getCreatedAt()));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,10 @@
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.username=sa
+spring.datasource.password=sa
+
+spring.jpa.hibernate.ddl-auto=create-drop
+
+# JWT \u914D\u7F6E (\u5F9E\u74B0\u5883\u8B8A\u6578\u8B80\u53D6\uFF0C\u5982\u679C\u6C92\u6709\u5247\u4F7F\u7528\u9810\u8A2D\u503C)
+jwt.secret=${JWT_SECRET:kM8DG2xjbQP7Rq4tYF3sZpW5vN1cL6aE9HmUdV0yX7C}
+jwt.expiration=${JWT_EXPIRATION:3600000}


### PR DESCRIPTION
- 實現 NoteServiceTest 包含 3 個測試方法
  - testCreateNote: 測試創建筆記功能
  - testGetNotes: 測試查詢筆記功能
  - testUpdateNote: 測試更新筆記功能
- 實現 NoteControllerTest 使用 MockMvc
  - testGetNotes: 測試 GET /notes API
- 配置 H2 記憶體資料庫作為測試環境
- 所有測試通過 (5/5)