### PR TITLE
feat: 整合 Swagger API 文檔與修復日誌記錄

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,13 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
+        <!-- SpringDoc OpenAPI (Swagger) 依賴 -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.9</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/jeannychiu/learningnotesapi/aspect/LogAspect.java
+++ b/src/main/java/com/jeannychiu/learningnotesapi/aspect/LogAspect.java
@@ -11,10 +11,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
@@ -24,12 +27,13 @@ public class LogAspect {
     private final ApiLogRepository apiLogRepository;
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
-    private ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper;
 
-    public LogAspect(ApiLogRepository apiLogRepository, JwtUtil jwtUtil, UserRepository userRepository) {
+    public LogAspect(ApiLogRepository apiLogRepository, JwtUtil jwtUtil, UserRepository userRepository, ObjectMapper mapper) {
         this.apiLogRepository = apiLogRepository;
         this.jwtUtil = jwtUtil;
         this.userRepository = userRepository;
+        this.mapper = mapper;
     }
 
     @Around("execution(* com.jeannychiu.learningnotesapi.controller..*(..))")
@@ -71,8 +75,8 @@ public class LogAspect {
         String responseBody = "";
 
         try {
-            // 將Request參數轉成字串 (RequestBody)
-            requestBody = mapper.writeValueAsString(joinPoint.getArgs());
+            // 使用新方法來提取 @RequestBody 參數
+            requestBody = extractRequestData(joinPoint, method);
             // 將ResponseBody轉成字串
             String fullResponseBody = mapper.writeValueAsString(result);
             
@@ -120,5 +124,51 @@ public class LogAspect {
             System.out.println("Failed to extract user ID: " + e.getMessage());
         }
         return null;
+    }
+
+    private String extractRequestData(ProceedingJoinPoint joinPoint, String httpMethod) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        Object[] args = joinPoint.getArgs();
+
+        // 對於 POST 和 PUT，只記錄 @RequestBody
+        if ("POST".equals(httpMethod) || "PUT".equals(httpMethod)) {
+            for (int i = 0; i < method.getParameterCount(); i++) {
+                if (method.getParameters()[i].isAnnotationPresent(RequestBody.class)) {
+                    try {
+                        return mapper.writeValueAsString(args[i]);
+                    } catch (JsonProcessingException e) {
+                        return "Failed to serialize: " + e.getMessage();
+                    }
+                }
+            }
+            return "";
+        }
+        // 對於 GET 和 DELETE，記錄所有參數
+        else {
+            try {
+                // 如果沒有參數，返回空字串
+                if (args.length == 0) {
+                    return "";
+                }
+
+                // 使用原本的方式記錄所有參數
+                return mapper.writeValueAsString(args);
+            } catch (JsonProcessingException e) {
+                // 如果序列化失敗，嘗試個別處理參數
+                StringBuilder params = new StringBuilder("[");
+                for (int i = 0; i < args.length; i++) {
+                    if (i > 0) params.append(",");
+                    try {
+                        params.append(mapper.writeValueAsString(args[i]));
+                    } catch (Exception ex) {
+                        // 對於無法序列化的物件，使用 toString()
+                        params.append("\"").append(args[i]).append("\"");
+                    }
+                }
+                params.append("]");
+                return params.toString();
+            }
+        }
     }
 }

--- a/src/main/java/com/jeannychiu/learningnotesapi/config/OpenApiConfig.java
+++ b/src/main/java/com/jeannychiu/learningnotesapi/config/OpenApiConfig.java
@@ -1,0 +1,42 @@
+package com.jeannychiu.learningnotesapi.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        // 1. 建立 Info 物件設定 API 基本資訊
+        Info info = new Info()
+                .title("線上學習筆記平台 API")
+                .description("提供使用者一個可以隨時做筆記，並且方便查詢過往筆記的服務。")
+                .version("1.0.0")
+                .contact(new Contact()
+                        .name("Jeanny Chiu")
+                        .email("jeannychiu608@gmail.com")
+                        .url("https://github.com/jeannychiu"));
+
+        // 2. 建立 SecurityScheme 設定 JWT 認證
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .description("請輸入登入後取得的 JWT token");
+
+        // 3. 組合成完整的 OpenAPI 物件
+        return new OpenAPI()
+                .info(info)
+                .components(new Components()
+                        .addSecuritySchemes("bearer", securityScheme)
+                )
+                .addSecurityItem(new SecurityRequirement()
+                        .addList("bearer"));
+    }
+}

--- a/src/main/java/com/jeannychiu/learningnotesapi/config/SecurityConfig.java
+++ b/src/main/java/com/jeannychiu/learningnotesapi/config/SecurityConfig.java
@@ -76,6 +76,15 @@ public class SecurityConfig {
                 auth.requestMatchers("/auth/register", "/auth/login").permitAll();
                 // 允許錯誤頁面
                 auth.requestMatchers("/error").permitAll();
+
+                // 允許 Swagger UI 和 API 文檔
+                auth.requestMatchers(
+                        "/swagger-ui/**",
+                        "/swagger-ui.html",
+                        "/v3/api-docs/**",
+                        "/swagger-resources/**",
+                        "/webjars/**"
+                ).permitAll();
                 
                 // 測試端點的處理完全交給 TestEndpointFilter
                 if (enableTestEndpoints) {


### PR DESCRIPTION
- 新增 SpringDoc OpenAPI 依賴
- 建立 OpenApiConfig 設定 API 文檔與 JWT 認證
- 更新 SecurityConfig 允許 Swagger UI 路徑
- 修復 LogAspect 的 request_body 記錄問題
  - POST/PUT 只記錄 @RequestBody 參數
  - GET/DELETE 保持記錄所有參數
  - 解決 LocalDateTime 序列化問題
- Swagger UI 可在 /swagger-ui/index.html 訪問