### PR TITLE
feat: 實作筆記搜尋建議功能

### DIFF
--- a/src/main/java/com/jeannychiu/learningnotesapi/controller/NotesController.java
+++ b/src/main/java/com/jeannychiu/learningnotesapi/controller/NotesController.java
@@ -2,6 +2,7 @@ package com.jeannychiu.learningnotesapi.controller;
 
 import com.jeannychiu.learningnotesapi.constant.RoleConstants;
 import com.jeannychiu.learningnotesapi.dto.CreateNoteRequest;
+import com.jeannychiu.learningnotesapi.dto.SearchSuggestionsResponse;
 import com.jeannychiu.learningnotesapi.dto.UpdateNoteRequest;
 import com.jeannychiu.learningnotesapi.model.Note;
 import com.jeannychiu.learningnotesapi.service.NoteService;
@@ -165,5 +166,31 @@ public class NotesController {
         noteService.deleteNote(id, userEmail, isAdmin);
         
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 取得搜尋關鍵字建議
+     *
+     * 根據使用者輸入的關鍵字，從筆記標題中提取相關的關鍵字建議。
+     * 支援最少2個字元的搜尋，並去除重複的建議。
+     *
+     * @param q 搜尋關鍵字 (至少2個字元)
+     * @param limit 返回建議的最大數量 (選填，預設值：5)
+     * @param authentication Spring Security 的認證物件
+     * @return 搜尋建議回應物件，HTTP 狀態碼 200
+     */
+    @GetMapping("/suggestions")
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    public ResponseEntity<SearchSuggestionsResponse> getSearchSuggestions (
+            @RequestParam String q,
+            @RequestParam(required = false) Integer limit,
+            Authentication authentication) {
+        String userEmail = authentication.getName();
+        boolean isAdmin = authentication.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals(RoleConstants.ROLE_ADMIN));
+
+        SearchSuggestionsResponse response = noteService.getSearchSuggestions(q, userEmail, isAdmin, limit);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/jeannychiu/learningnotesapi/dto/SearchSuggestionsResponse.java
+++ b/src/main/java/com/jeannychiu/learningnotesapi/dto/SearchSuggestionsResponse.java
@@ -1,0 +1,10 @@
+package com.jeannychiu.learningnotesapi.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SearchSuggestionsResponse {
+    private List<SuggestionItem> suggestions;
+}

--- a/src/main/java/com/jeannychiu/learningnotesapi/dto/SuggestionItem.java
+++ b/src/main/java/com/jeannychiu/learningnotesapi/dto/SuggestionItem.java
@@ -1,0 +1,11 @@
+package com.jeannychiu.learningnotesapi.dto;
+
+import lombok.Data;
+
+@Data
+public class SuggestionItem {
+    private Long id;
+    private String title;
+    private String type;
+    private String matchedText;
+}


### PR DESCRIPTION
- 新增 GET /notes/suggestions API 端點
- 實作從筆記標題提取關鍵字的邏輯
- 前端新增搜尋建議下拉選單
- 實作 300ms debounce 優化效能
- 使用 GROUP BY 去除重複標題
- 支援最少 2 字元觸發搜尋建議